### PR TITLE
backend: add metering proxy

### DIFF
--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -19,7 +19,6 @@ import {
   GroupVersionKind,
   modelFor,
   referenceForModel,
-  resourceURL,
 } from '../module/k8s';
 import {
   Kebab,
@@ -48,17 +47,7 @@ const { common } = Kebab.factory;
 const menuActions = [...common];
 
 const dataURL = (obj, format='json') => {
-  const serviceModel = modelFor('Service');
-  return resourceURL(serviceModel, {
-    ns: obj.metadata.namespace,
-    name: 'https:reporting-operator:http',
-    path: 'proxy/api/v1/reports/get',
-    queryParams: {
-      name: obj.metadata.name,
-      format,
-      namespace: obj.metadata.namespace,
-    },
-  });
+  return `${window.SERVER_FLAGS.meteringBaseURL}/api/v1/reports/get?name=${obj.metadata.name}&namespace=${obj.metadata.namespace}&format=${format}`;
 };
 
 const ChargebackNavBar: React.SFC<{match: {url: string}}> = props => <div>

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -28,6 +28,7 @@ declare interface Window {
     loginURL: string;
     logoutRedirect: string;
     logoutURL: string;
+    meteringBaseURL: string;
     prometheusBaseURL: string;
     prometheusTenancyBaseURL: string;
     requestTokenURL: string;


### PR DESCRIPTION
@dtaylor113 I have it working. You'll have to build an image and push to your cluster to test. For development, you might want to keep using the kube proxy as before.